### PR TITLE
fix: Does not show login failed message in MainActivity

### DIFF
--- a/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
@@ -32,21 +32,12 @@ public class MainActivity extends AppCompatActivity {
 
         getWindow().setStatusBarColor(getApplicationContext().getColor(R.color.colorBackground));
 
-        //
         auth = FirebaseAuth.getInstance();
         currentUser = auth.getCurrentUser();
-        updateUI(currentUser);
-        Log.d(TAG, "onCreate: currentUser=" + currentUser);
 
         // Word list
         wordList.setLayoutManager(new LinearLayoutManager(this));
         wordList.setHasFixedSize(true);
         wordList.setAdapter(new WordListAdapter());
-    }
-
-    private void updateUI(FirebaseUser currentUser) {
-        if (currentUser == null) {
-            Snackbar.make(background, "로그인에 실패하였습니다.", Snackbar.LENGTH_LONG).show();
-        }
     }
 }

--- a/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
@@ -1,6 +1,5 @@
 package com.tronix.kwakvoca;
 
-import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -9,16 +8,9 @@ import android.os.Bundle;
 import android.util.Log;
 import android.widget.LinearLayout;
 
-import com.google.android.gms.auth.api.signin.GoogleSignIn;
-import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
 import com.google.android.material.snackbar.Snackbar;
-import com.google.firebase.auth.AuthCredential;
-import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
-import com.google.firebase.auth.GoogleAuthProvider;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -40,38 +32,16 @@ public class MainActivity extends AppCompatActivity {
 
         getWindow().setStatusBarColor(getApplicationContext().getColor(R.color.colorBackground));
 
-        GoogleSignInAccount account = GoogleSignIn.getLastSignedInAccount(getApplicationContext());
+        //
         auth = FirebaseAuth.getInstance();
         currentUser = auth.getCurrentUser();
-
-        if (account != null) {
-            firebaseAuthWithGoogle(account);
-        }
+        updateUI(currentUser);
+        Log.d(TAG, "onCreate: currentUser=" + currentUser);
 
         // Word list
         wordList.setLayoutManager(new LinearLayoutManager(this));
         wordList.setHasFixedSize(true);
         wordList.setAdapter(new WordListAdapter());
-    }
-
-    private void firebaseAuthWithGoogle(GoogleSignInAccount account) {
-        Log.d(TAG, "firebaseAuthWithGoogle: " + account.getId());
-
-        AuthCredential credential = GoogleAuthProvider.getCredential(account.getIdToken(), null);
-        auth.signInWithCredential(credential)
-                .addOnCompleteListener(this, new OnCompleteListener<AuthResult>() {
-                    @Override
-                    public void onComplete(@NonNull Task<AuthResult> task) {
-                        if (task.isSuccessful()) {
-                            Log.d(TAG, "signInWithCredential: success");
-                            FirebaseUser currentUser = auth.getCurrentUser();
-                            updateUI(currentUser);
-                        } else {
-                            Log.w(TAG, "signInWithCredential: failure", task.getException());
-                            Snackbar.make(background, "로그인에 실패하였습니다.", Snackbar.LENGTH_LONG).show();
-                        }
-                    }
-                });
     }
 
     private void updateUI(FirebaseUser currentUser) {

--- a/app/src/main/java/com/tronix/kwakvoca/SignInActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/SignInActivity.java
@@ -6,7 +6,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -112,11 +111,6 @@ public class SignInActivity extends AppCompatActivity {
         if (currentUser == null) {
             Snackbar.make(background, "로그인에 실패하였습니다.", Snackbar.LENGTH_LONG).show();
         } else {
-            SharedPreferences preferences = getSharedPreferences("DATA", MODE_PRIVATE);
-            SharedPreferences.Editor editor = preferences.edit();
-            editor.putBoolean("isSignedIn", true);
-            editor.apply();
-
             Intent intent = new Intent(getApplicationContext(), MainActivity.class);
             startActivity(intent);
             finish();

--- a/app/src/main/java/com/tronix/kwakvoca/SplashActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/SplashActivity.java
@@ -3,10 +3,12 @@ package com.tronix.kwakvoca;
 import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.Log;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 
 public class SplashActivity extends AppCompatActivity {
 
@@ -25,10 +27,10 @@ public class SplashActivity extends AppCompatActivity {
 
     private class SplashHandler implements Runnable {
         public void run() {
-            SharedPreferences preferences = getSharedPreferences("DATA", MODE_PRIVATE);
-            boolean isSignedIn = preferences.getBoolean("isSignedIn", false);
-            Log.d(TAG, "isSignedIn=" + isSignedIn);
-            startActivity(setActivityToMove(isSignedIn));
+            FirebaseAuth auth = FirebaseAuth.getInstance();
+            FirebaseUser currentUser = auth.getCurrentUser();
+            startActivity(setActivityToMove(currentUser));
+
             overridePendingTransition(0, R.anim.splash_fade_out);
             SplashActivity.this.finish();
         }
@@ -37,12 +39,15 @@ public class SplashActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() { }
 
-    private Intent setActivityToMove(boolean isSignedIn) {
+    private Intent setActivityToMove(FirebaseUser currentUser) {
         Intent intentSignInActivity = new Intent(getApplicationContext(), SignInActivity.class);
         Intent intentMainActivity = new Intent(getApplicationContext(), MainActivity.class);
-        if (isSignedIn) {
+
+        if (currentUser != null) {
+            Log.d(TAG, "setActivityToMove: currentUser exists. Moving to MainActivity.");
             return intentMainActivity;
         } else {
+            Log.d(TAG, "setActivityToMove: currentUser does not exist. Moving to SignInActivity.");
             return intentSignInActivity;
         }
     }


### PR DESCRIPTION
### 전에 로그인을 했음에도 불구하고 로그인 실패 메시지가 뜨는 현상을 해결함.
* MainActivity에서는 로그인을 다시 한번 하지 않는 구조로 바뀜.
* 기존에는 SplashActivity에서 SharedPreferences의 boolean 값 isSignedIn을 불러와 사용자가 전에 로그인을 했는지 안했는지 검사했다면, 이번 수정 사항에서는 SplashActivity에서 바로 currentUser가 null인지 아닌지 확인함.

closes: #22 