### PR TITLE
fix(UI): Different radius in dialog background

### DIFF
--- a/app/src/main/res/drawable/dialog_background.xml
+++ b/app/src/main/res/drawable/dialog_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="@color/colorPrimary" />
-    <corners android:radius="20dp" />
+    <corners android:radius="@dimen/dialog_radius" />
 </shape>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Dialogs -->
-    <dimen name="dialog_radius">30dp</dimen>
+    <dimen name="dialog_radius">20dp</dimen>
     <dimen name="dialog_title_text_size">25sp</dimen>
     <dimen name="dialog_title_margin_horizontal">30dp</dimen>
     <dimen name="dialog_content_text_size">17sp</dimen>


### PR DESCRIPTION
### 단어 삭제 다이얼로그의 위아래 곡률이 맞지 않는 문제 해결
closes: #44 

> delete_word_dialog
>
> ![Screenshot_1579959950](https://user-images.githubusercontent.com/48079406/73122120-778b9e00-3fc4-11ea-965c-f110b22e43f6.png)

