### PR TITLE
feat: Word action dialog, also able to copy words

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,15 +4,12 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="modules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-          </set>
-        </option>
         <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>

--- a/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/MainActivity.java
@@ -1,5 +1,8 @@
 package com.tronix.kwakvoca;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -48,6 +51,8 @@ public class MainActivity extends AppCompatActivity {
 
     FirebaseFirestore db;
     CollectionReference reference;
+
+//    ClipboardManager clipboardManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -203,7 +208,7 @@ public class MainActivity extends AppCompatActivity {
                 });
     }
 
-    public void restoreWord(WordData data, final LinearLayout background) {
+    private void restoreWord(WordData data, final LinearLayout background) {
         reference = FirebaseFirestore.getInstance().collection("words");
 
         reference.document(data.documentId)
@@ -220,6 +225,37 @@ public class MainActivity extends AppCompatActivity {
                         Log.w(TAG, "Error restoring word document", e);
                     }
                 });
+    }
+
+    public void copyWord(Context context, LinearLayout background, WordData data) {
+
+        String meaning;
+
+        if (data.meaning.contains("\n")) {
+            String[] meanings = data.meaning.split("\n");
+            String builderString;
+            String space = "";
+            StringBuilder meaningBuilder = new StringBuilder();
+            for (String string : meanings) {
+                builderString = space + string;
+                meaningBuilder.append(builderString);
+                space = " ";
+            }
+            meaning = meaningBuilder.toString();
+        } else {
+            meaning = data.meaning;
+        }
+
+        String clipText = data.word + ": " + meaning;
+        ClipData clip = ClipData.newPlainText(data.word, clipText);
+        ClipboardManager manager = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (manager != null) {
+            manager.setPrimaryClip(clip);
+        } else {
+            Log.d(TAG, "copyWord: ClipboardManager=null");
+        }
+
+        Snackbar.make(background, R.string.result_main_copied_word, Snackbar.LENGTH_SHORT).show();
     }
 
     private void checkForUpdates() {

--- a/app/src/main/java/com/tronix/kwakvoca/WordActionDialog.java
+++ b/app/src/main/java/com/tronix/kwakvoca/WordActionDialog.java
@@ -39,6 +39,7 @@ class WordActionDialog {
 
         // Buttons (Actually LinearLayout)
         LinearLayout deleteWord = dialog.findViewById(R.id.btn_delete_word);
+        LinearLayout copyWord = dialog.findViewById(R.id.btn_copy_word);
 
         // Delete word button
         deleteWord.setOnClickListener(new View.OnClickListener() {
@@ -48,6 +49,16 @@ class WordActionDialog {
                 DeleteWordDialog deleteWordDialog =
                         new DeleteWordDialog(applicationContext, background, data);
                 deleteWordDialog.show();
+            }
+        });
+
+        // Copy word button
+        copyWord.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dialog.dismiss();
+                MainActivity mainActivity = new MainActivity();
+                mainActivity.copyWord(applicationContext, background, data);
             }
         });
     }

--- a/app/src/main/java/com/tronix/kwakvoca/WordActionDialog.java
+++ b/app/src/main/java/com/tronix/kwakvoca/WordActionDialog.java
@@ -1,0 +1,54 @@
+package com.tronix.kwakvoca;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.view.View;
+import android.view.Window;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import java.util.Objects;
+
+class WordActionDialog {
+
+    private final String TAG = "WordActionDialog";
+    private Context applicationContext;
+    private LinearLayout background;
+    private WordData data;
+
+    WordActionDialog(Context applicationContext, LinearLayout background, WordData data) {
+        this.applicationContext = applicationContext;
+        this.background = background;
+        this.data = data;
+    }
+
+    void show() {
+        // Show dialog
+        final Dialog dialog = new Dialog(applicationContext);
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+        dialog.setContentView(R.layout.word_action_dialog);
+        Objects.requireNonNull(dialog.getWindow())
+                .setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        dialog.show();
+
+        // Set dialog's title as a selected word
+        TextView wordView = dialog.findViewById(R.id.tv_word);
+        wordView.setText(data.word);
+
+        // Buttons (Actually LinearLayout)
+        LinearLayout deleteWord = dialog.findViewById(R.id.btn_delete_word);
+
+        // Delete word button
+        deleteWord.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dialog.dismiss();
+                DeleteWordDialog deleteWordDialog =
+                        new DeleteWordDialog(applicationContext, background, data);
+                deleteWordDialog.show();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/tronix/kwakvoca/WordListAdapter.java
+++ b/app/src/main/java/com/tronix/kwakvoca/WordListAdapter.java
@@ -51,10 +51,8 @@ public class WordListAdapter extends RecyclerView.Adapter<WordListAdapter.ViewHo
             public boolean onLongClick(View v) {
                 Log.d(TAG, "onLongClick: clicked item=" + word + "  document id=" + documentId);
 
-//                DeleteWordDialog deleteWordDialog = new DeleteWordDialog(applicationContext, background, wordData);
-//                deleteWordDialog.show();
-
-                WordActionDialog wordActionDialog = new WordActionDialog(applicationContext, background, wordData);
+                WordActionDialog wordActionDialog =
+                        new WordActionDialog(applicationContext, background, wordData);
                 wordActionDialog.show();
 
                 return true;

--- a/app/src/main/java/com/tronix/kwakvoca/WordListAdapter.java
+++ b/app/src/main/java/com/tronix/kwakvoca/WordListAdapter.java
@@ -51,8 +51,11 @@ public class WordListAdapter extends RecyclerView.Adapter<WordListAdapter.ViewHo
             public boolean onLongClick(View v) {
                 Log.d(TAG, "onLongClick: clicked item=" + word + "  document id=" + documentId);
 
-                DeleteWordDialog deleteWordDialog = new DeleteWordDialog(applicationContext, background, wordData);
-                deleteWordDialog.show();
+//                DeleteWordDialog deleteWordDialog = new DeleteWordDialog(applicationContext, background, wordData);
+//                deleteWordDialog.show();
+
+                WordActionDialog wordActionDialog = new WordActionDialog(applicationContext, background, wordData);
+                wordActionDialog.show();
 
                 return true;
             }

--- a/app/src/main/res/drawable/ic_copy_white.xml
+++ b/app/src/main/res/drawable/ic_copy_white.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="25dp"
+    android:height="25dp" android:tint="#FFFFFF"
+    android:viewportWidth="24.0" android:viewportHeight="24.0">
+    <path android:fillColor="#FF000000" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+</vector>

--- a/app/src/main/res/drawable/word_action_button.xml
+++ b/app/src/main/res/drawable/word_action_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimary" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimaryDark" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/word_action_last_button.xml
+++ b/app/src/main/res/drawable/word_action_last_button.xml
@@ -3,13 +3,15 @@
     <item android:state_pressed="false">
         <shape android:shape="rectangle">
             <solid android:color="@color/colorPrimary" />
-            <corners android:bottomLeftRadius="20dp" android:bottomRightRadius="20dp" />
+            <corners android:bottomLeftRadius="15dp" android:bottomRightRadius="15dp" />
+            <padding android:bottom="10dp" />
         </shape>
     </item>
     <item android:state_pressed="true">
         <shape android:shape="rectangle">
             <solid android:color="@color/colorPrimaryDark" />
-            <corners android:bottomLeftRadius="20dp" android:bottomRightRadius="20dp" />
+            <corners android:bottomLeftRadius="15dp" android:bottomRightRadius="15dp" />
+            <padding android:bottom="10dp" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/word_action_last_button.xml
+++ b/app/src/main/res/drawable/word_action_last_button.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimary" />
+            <corners android:bottomLeftRadius="20dp" android:bottomRightRadius="20dp" />
+        </shape>
+    </item>
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/colorPrimaryDark" />
+            <corners android:bottomLeftRadius="20dp" android:bottomRightRadius="20dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/delete_word_dialog.xml
+++ b/app/src/main/res/layout/delete_word_dialog.xml
@@ -18,8 +18,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp">
+            android:layout_marginStart="@dimen/dialog_title_margin_horizontal"
+            android:layout_marginEnd="@dimen/dialog_title_margin_horizontal">
 
             <ImageView
                 android:layout_width="35dp"
@@ -82,7 +82,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="10dp"
                 android:fontFamily="@font/nanum_square_round_bold"
-                android:text="@string/action_delete_world"
+                android:text="@string/action_delete"
                 android:textColor="@color/colorWhite"
                 android:textSize="15sp" />
 

--- a/app/src/main/res/layout/word_action_dialog.xml
+++ b/app/src/main/res/layout/word_action_dialog.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginStart="20dp"
+    android:layout_marginEnd="20dp"
+    android:background="@drawable/dialog_background"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="60dp">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@drawable/dialog_title_background" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp">
+
+            <TextView
+                android:id="@+id/tv_word"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:fontFamily="@font/nanum_square_round_extra_bold"
+                android:maxLines="1"
+                android:text="@string/sample_word"
+                android:textColor="@color/colorWhite"
+                android:textSize="@dimen/dialog_title_text_size" />
+
+        </LinearLayout>
+
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/btn_delete_word"
+            style="@style/WordActionLastContentLinearLayout"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            tools:ignore="UseCompoundDrawables">
+
+            <ImageView
+                style="@style/WordActionContentImageView"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:importantForAccessibility="no"
+                app:srcCompat="@drawable/ic_delete_white" />
+
+            <TextView
+                style="@style/WordActionContentTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/action_delete_word" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/word_action_dialog.xml
+++ b/app/src/main/res/layout/word_action_dialog.xml
@@ -11,7 +11,8 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="60dp">
+        android:layout_height="60dp"
+        android:layout_marginBottom="5dp">
 
         <View
             android:layout_width="match_parent"
@@ -43,6 +44,28 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/btn_copy_word"
+            style="@style/WordActionContentLinearLayout"
+            android:layout_width="match_parent"
+            android:layout_height="40dp"
+            tools:ignore="UseCompoundDrawables">
+
+            <ImageView
+                style="@style/WordActionContentImageView"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:importantForAccessibility="no"
+                app:srcCompat="@drawable/ic_copy_white" />
+
+            <TextView
+                style="@style/WordActionContentTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/action_copy" />
+
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/btn_delete_word"

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -10,6 +10,7 @@
     <string name="action_delete_word">Delete word</string>
     <string name="action_done">Done</string>
     <string name="action_add">Add</string>
+    <string name="action_copy">Copy</string>
 
     <!-- activity_sign_in -->
     <string name="text_login">Sign in</string>
@@ -24,6 +25,7 @@
     <string name="result_main_added_word">The word has been added.</string>
     <string name="result_main_deleted_word">The word has been deleted.</string>
     <string name="result_main_restored_word">The word has been restored.</string>
+    <string name="result_main_copied_word">The word has been copied to the clipboard.</string>
     <string name="error_main_adding_word">There was a problem while the word was being added.</string>
 
     <!-- delete_word_dialog -->

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -6,7 +6,8 @@
 
     <!-- Actions -->
     <string name="action_cancel">Cancel</string>
-    <string name="action_delete_world">Delete</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_delete_word">Delete word</string>
     <string name="action_done">Done</string>
     <string name="action_add">Add</string>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,7 +3,7 @@
     <!-- Dialogs -->
     <dimen name="dialog_radius">20dp</dimen>
     <dimen name="dialog_title_text_size">25sp</dimen>
-    <dimen name="dialog_title_margin_horizontal">30dp</dimen>
+    <dimen name="dialog_title_margin_horizontal">20dp</dimen>
     <dimen name="dialog_content_text_size">17sp</dimen>
     <dimen name="dialog_content_margin">20dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="action_delete_word">단어 삭제</string>
     <string name="action_done">완료</string>
     <string name="action_add">추가</string>
+    <string name="action_copy">복사</string>
 
     <!-- activity_sign_in -->
     <string name="text_login">로그인</string>
@@ -33,6 +34,7 @@
     <string name="result_main_added_word">단어가 추가되었어요.</string>
     <string name="result_main_deleted_word">단어가 삭제되었어요.</string>
     <string name="result_main_restored_word">단어가 복원되었어요.</string>
+    <string name="result_main_copied_word">단어가 클립보드에 복사되었어요.</string>
     <string name="error_main_adding_word">단어가 추가되는 중에 문제가 생겼어요.</string>
 
     <!-- delete_word_dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,8 @@
 
     <!-- Actions -->
     <string name="action_cancel">취소</string>
-    <string name="action_delete_world">삭제</string>
+    <string name="action_delete">삭제</string>
+    <string name="action_delete_word">단어 삭제</string>
     <string name="action_done">완료</string>
     <string name="action_add">추가</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,4 +19,33 @@
         <item name="android:layout_marginEnd">25dp</item>
         <item name="android:layout_marginBottom">30dp</item>
     </style>
+
+    <style name="WordActionContentLinearLayout">
+        <item name="android:background">@drawable/word_action_button</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:paddingLeft">@dimen/dialog_content_margin</item>
+        <item name="android:paddingRight">@dimen/dialog_content_margin</item>
+    </style>
+
+    <style name="WordActionLastContentLinearLayout">
+        <item name="android:background">@drawable/word_action_last_button</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:paddingLeft">@dimen/dialog_content_margin</item>
+        <item name="android:paddingRight">@dimen/dialog_content_margin</item>
+    </style>
+
+    <style name="WordActionContentImageView">
+        <item name="android:layout_gravity">center</item>
+        <item name="android:scaleType">fitCenter</item>
+    </style>
+
+    <style name="WordActionContentTextView">
+        <item name="android:layout_gravity">center</item>
+        <item name="android:layout_marginStart">10dp</item>
+        <item name="android:fontFamily">@font/nanum_square_round_bold</item>
+        <item name="android:textColor">@color/colorWhite</item>
+        <item name="android:textSize">18sp</item>
+    </style>
 </resources>


### PR DESCRIPTION
### 단어를 길게 눌렀을 때 단어 액션 다이얼로그 출현
사용자가 메인 화면에서 단어를 길게 눌렀을 때 여러 가지 액션을 실행 가능하도록 다이얼로그를 추가함.
따라서, 기존에 단어를 길게 누르면 제공했던 삭제 기능이 액션 다이얼로그로 옮겨짐.

새롭게 추가된 기능으로는 **단어 복사** 기능이 있는데,
뜻이 '안드로이드'인 단어 'android'가 있을 때, 복사 버튼을 누르면 클립보드에 단어를 아래와 같은 형식으로 저장함.
**android: 안드로이드**

closes: #36 

> activity_main
>
>> word_action_dialog
>>
>>![Screenshot_1583944954](https://user-images.githubusercontent.com/48079406/76441809-5c091500-6403-11ea-90dd-e8da3f0d8461.png)
