### PR TITLE
feat: Show help for updating when pressing the help button

### DIFF
--- a/app/src/main/java/com/tronix/kwakvoca/AddWordsActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/AddWordsActivity.java
@@ -123,10 +123,8 @@ public class AddWordsActivity extends AppCompatActivity {
         word.setText(data.word);
         documentId = data.documentId;
 
-//        String[] meaningStrings = data.meaning.split("\n");
         for (int i = 0; i < data.meanings.size(); i++) {
             addMeaningField();
-//            meanings.get(i).setText(meaningStrings[i]);  // Fill meaning fields
             meanings.get(i).setText(data.meanings.get(i));
         }
     }

--- a/app/src/main/java/com/tronix/kwakvoca/UpdateActivity.java
+++ b/app/src/main/java/com/tronix/kwakvoca/UpdateActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.Nullable;
@@ -27,6 +28,7 @@ public class UpdateActivity extends AppCompatActivity {
 
     TextView newVersion, currentVersion, description, improvements, date;
     Button update;
+    ImageButton help;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,6 +38,7 @@ public class UpdateActivity extends AppCompatActivity {
         newVersion = findViewById(R.id.text_new_version);
         currentVersion = findViewById(R.id.text_current_version);
         update = findViewById(R.id.btn_update);
+        help = findViewById(R.id.btn_help);
         description = findViewById(R.id.text_description);
         improvements = findViewById(R.id.text_improvements);
         date = findViewById(R.id.text_update_date);
@@ -45,6 +48,22 @@ public class UpdateActivity extends AppCompatActivity {
         initializeUI();
 
         checkForUpdates();
+
+        // Help button
+        help.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                DialogContents contents = new DialogContents();
+                contents.title = getString(R.string.action_help);
+                contents.text = getString(R.string.dialog_text_help_update);
+                contents.yes = getString(R.string.action_ok);
+                contents.iconResId = R.drawable.ic_help_white;
+
+                DefaultDialog dialog = new DefaultDialog(contents, DefaultDialog.DEFAULT,
+                        UpdateActivity.this);
+                dialog.show();
+            }
+        });
 
         // Update button
         update.setOnClickListener(new View.OnClickListener() {
@@ -61,6 +80,8 @@ public class UpdateActivity extends AppCompatActivity {
         currentVersion.setTextColor(getColor(R.color.colorOrange));
         update.setBackground(getDrawable(R.drawable.button_update_unavailable));
         update.setText(R.string.action_see_version_logs);
+        help.setBackground(null);
+        help.setEnabled(false);
 
         String descriptionText = getString(R.string.text_current_version_description);
         description.setText(descriptionText);
@@ -102,6 +123,10 @@ public class UpdateActivity extends AppCompatActivity {
 
 
         if (Versions.CURRENT_VERSION_CODE < newVersionData.versionInt) {
+
+            // Show help button
+            help.setBackground(getDrawable(R.drawable.button_help));
+            help.setEnabled(true);
 
             // Set updateUrl
             updateUrl = "https://github.com/Kwak04/KwakVoca/releases/tag/" + newVersionData.version;

--- a/app/src/main/res/layout/activity_update.xml
+++ b/app/src/main/res/layout/activity_update.xml
@@ -18,6 +18,20 @@
             android:layout_height="wrap_content"
             android:text="@string/title_update" />
 
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ImageButton
+            android:id="@+id/btn_help"
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:layout_gravity="center"
+            android:background="@drawable/button_help"
+            android:contentDescription="@string/action_help"
+            android:scaleType="fitCenter" />
+
     </LinearLayout>
 
     <ScrollView

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -54,4 +54,5 @@
     <string name="action_update">Update</string>
     <string name="action_see_version_logs">See version logs</string>
     <string name="text_current_version_description">Yay! You\'re currently using the latest version!</string>
+    <string name="dialog_text_help_update">Press the \'Asset\' button and install an apk file in the website(Github) which is showed by pressing UPDATE button.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <!-- default_dialog -->
     <string name="dialog_warning_delete_word">단어를 삭제하시겠어요?</string>
     <string name="dialog_text_help_multisense">단어에 뜻을 2개 이상 추가하려면 뜻 칸에 뜻을 입력한 후 키보드의 다음 버튼을 누르세요.</string>
+    <string name="dialog_text_help_update">업데이트하기 버튼을 누르고 표시되는 웹사이트(Github)에서 \'Asset\' 버튼을 누르고 apk 파일을 다운로드 후 설치하세요.</string>
 
     <!-- activity_add_words -->
     <string name="title_add_word">단어 추가</string>


### PR DESCRIPTION
### 업데이트 도움말 추가
새로운 업데이트가 있을 시 업데이트 화면에 도움말 버튼이 생김.
도움말의 내용은 다음과 같음.

> **ko-kr**
> 업데이트하기 버튼을 누르고 표시되는 웹사이트(Github)에서 'Asset' 버튼을 누르고 apk 파일을 다운로드 후 설치하세요.

> **en-us**
> Press the 'Asset' button and install an apk file in the website(Github) which is showed by pressing UPDATE button.

closes: #70 